### PR TITLE
Remove dependency from Unity

### DIFF
--- a/Core/Core.Platform.Android/Core.Platform.Android.csproj
+++ b/Core/Core.Platform.Android/Core.Platform.Android.csproj
@@ -72,18 +72,6 @@
     <Reference Include="System.Xml">
       <HintPath>..\..\..\..\..\..\..\..\..\..\..\..\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0\System.Xml.dll</HintPath>
     </Reference>
-    <Reference Include="CommonServiceLocator">
-      <HintPath>..\..\packages\Unity.5.8.6\lib\netstandard2.0\CommonServiceLocator.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.Abstractions">
-      <HintPath>..\..\packages\Unity.5.8.6\lib\netstandard2.0\Unity.Abstractions.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.Container">
-      <HintPath>..\..\packages\Unity.5.8.6\lib\netstandard2.0\Unity.Container.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.ServiceLocation">
-      <HintPath>..\..\packages\Unity.5.8.6\lib\netstandard2.0\Unity.ServiceLocation.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

--- a/Core/Core.Platform.Android/packages.config
+++ b/Core/Core.Platform.Android/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NuGet.Build.Packaging" version="0.2.0" targetFramework="monoandroid71" developmentDependency="true" />
-  <package id="Unity" version="5.8.6" targetFramework="monoandroid80" />
 </packages>

--- a/Core/Core.Platform.iOS/Core.Platform.iOS.csproj
+++ b/Core/Core.Platform.iOS/Core.Platform.iOS.csproj
@@ -58,18 +58,6 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
-    <Reference Include="CommonServiceLocator">
-      <HintPath>..\..\packages\Unity.5.8.6\lib\netstandard2.0\CommonServiceLocator.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.Abstractions">
-      <HintPath>..\..\packages\Unity.5.8.6\lib\netstandard2.0\Unity.Abstractions.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.Container">
-      <HintPath>..\..\packages\Unity.5.8.6\lib\netstandard2.0\Unity.Container.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.ServiceLocation">
-      <HintPath>..\..\packages\Unity.5.8.6\lib\netstandard2.0\Unity.ServiceLocation.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MobileCoreIOS.cs" />

--- a/Core/Core.Platform.iOS/packages.config
+++ b/Core/Core.Platform.iOS/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NuGet.Build.Packaging" version="0.2.2" targetFramework="xamarinios10" developmentDependency="true" />
-  <package id="Unity" version="5.8.6" targetFramework="xamarinios10" />
   <package id="Xamarin.Forms" version="2.5.1.444934" targetFramework="xamarinios10" />
 </packages>

--- a/Core/Core/Core.csproj
+++ b/Core/Core/Core.csproj
@@ -18,7 +18,6 @@
   <ItemGroup>
     <PackageReference Include="System.Json" Version="4.4.0" />
     <PackageReference Include="NuGet.Build.Packaging" Version="0.2.0" />
-    <PackageReference Include="Unity" Version="5.8.6" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Storage\" />

--- a/Core/Core/Utils/ServiceFinder.cs
+++ b/Core/Core/Utils/ServiceFinder.cs
@@ -1,11 +1,12 @@
 ﻿using System;
-using Unity;
+using System.Collections.Generic;
 
 namespace AeroGear.Mobile.Core.Utils
 {
     public static class ServiceFinder
     {
-        private static readonly UnityContainer Container = new UnityContainer();
+        private static Dictionary<Type, Type> typeMapping = new Dictionary<Type, Type>();
+        private static Dictionary<Type, Object> instanceMapping = new Dictionary<Type, Object>();
 
         /// <summary>
         ///     Resolve the correct implementation for the type
@@ -14,23 +15,31 @@ namespace AeroGear.Mobile.Core.Utils
         /// <returns>an instance of the correct implementation class</returns>
         public static T Resolve<T>()
         {
-            return Container.Resolve<T>();
+            Type type = typeof(T);
+            if (instanceMapping.ContainsKey(type)) {
+                return (T) instanceMapping[type];
+            }
+
+            if (typeMapping.ContainsKey(type)) {
+                return (T) Activator.CreateInstance(typeMapping[type]);
+            }
+            throw new System.Exception(String.Format("No mapping could been found for type {0}", type.Name));
         }
 
         public static void RegisterType<TFrom, TTo>() where TTo : TFrom
         {
-            Container.RegisterType<TFrom, TTo>();
+            typeMapping[typeof(TFrom)] = typeof(TTo);
         }
 
         public static void RegisterInstance<TInstance>(TInstance instance)
         {
-            Container.RegisterInstance<TInstance>(instance);
+            instanceMapping[typeof(TInstance)] = instance;
         }
 
         public static bool IsRegistered<TInstance>()
         {
-            return Container.IsRegistered<TInstance>();
+            Type type = typeof(TInstance);
+            return typeMapping.ContainsKey(type) || instanceMapping.ContainsKey(type);
         }
-
     }
 }


### PR DESCRIPTION
# Motivation

We don't want to put dependency of injection libraries like Unity since the user could use his own library

# Changes

* Implemented the ServiceFinder class without the use of the Unity Library
* Removed Unity from the list of nuget dependencies